### PR TITLE
fix(statics): refresh snack statistics whenever the screen gains focus

### DIFF
--- a/src/screens/Statics/index.tsx
+++ b/src/screens/Statics/index.tsx
@@ -25,8 +25,8 @@ export function Statics(){
   const [isInsideDietSnacksSequence, setIsInsideDietSnacksSequence] = useState(0)
 
 
-  const navigation = useNavigation()
-  const route = useRoute()
+  const navigation = useNavigation<NavigationProp<AppRoutes>>();
+  const route = useRoute<RouteProp<AppRoutes, 'statics'>>();
 
   async function fetchDatas(){
     const { percent } = route.params as RouteParam


### PR DESCRIPTION
Troquei useEffect([]) por useFocusEffect, assim fetchData roda sempre que a tela Statics recebe foco.

Isso garante que as estatísticas reflitam qualquer refeição adicionada/alterada em outras telas, sem precisar recarregar o app.